### PR TITLE
Add additional OCR misreadings tilde, unicode en/em dash, 0-O

### DIFF
--- a/MysticManager.ahk
+++ b/MysticManager.ahk
@@ -239,20 +239,22 @@ ExtractNumbers(MyString){
 	lastwasnumber := 0
 	Loop, Parse, MyString
 	{
-		; Only replace O with a zero if adjacent to a number
-		IfInString,A_LoopField,O
-			If (lastwasnumber = 1)
-			{
-				NewVar .= "0"
-				lastwasnumber := 1
-			}
 		If A_LoopField is Number
 		{
 			NewVar .= A_LoopField
 			lastwasnumber := 1
 		}
 		else
-			lastwasnumber := 0
+		{
+			; Only replace O with a zero if adjacent to a number
+			If (lastwasnumber = 1)
+			{
+				IfInString,A_LoopField,O
+					NewVar .= "0"
+				else
+					lastwasnumber := 0
+			}
+		}
 		IfInString,A_LoopField,.
 		{
 			if (firstdot = 0){


### PR DESCRIPTION
This fixes a all the problems I was having rerolling damage range on items, all due to OCR errors. The dash was being detected tilde or as Unicode Em/En Dash (not ASCII version). Sometimes Zero would come out as Letter O too which would mess up the number parser as it needs to consider O as 0 when preceded by another number.

-- Tilde -> -
-- Unicode En Dash -> -
-- Unicode Em Dash -> -
-- Letter O is replaced with Zero if it follows a number, fixes 170O or 17O0 becoming 170

Also adds parsed Damage Range output and parsed computed Roll value to output-sane.txt for better debugging.